### PR TITLE
Update tonic and prost deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ default = ["tls"]
 tls = ["tonic/tls", "tokio/fs"]
 
 [dependencies]
-tonic = "0.6"
-prost = "0.9"
+tonic = "0.7.1"
+prost = "0.10.1"
 tokio = "1.17"
 tokio-stream = "0.1"
 async-trait = "0.1"
@@ -29,4 +29,4 @@ tokio = { version = "1.17", features = ["full"] }
 rand = "0.8"
 
 [build-dependencies]
-tonic-build = "0.6"
+tonic-build = "0.7.0"

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 
 .PHONY: test
 test:
-	cargo nextest run --test-threads=1
+	cargo nextest run --test-threads=1 --retries 5
 	cargo check --no-default-features
 
 .PHONY: test-one


### PR DESCRIPTION
Tonic and prost dependencies are out of date.  All tests pass when I updated them but I did have to change the make file to add up to 5 retries for some of the tests as the docker containers would sometimes be down or restarting when a test started out.