### PR TITLE
use i64 for lease ttl and LeaseId type for ttl request

### DIFF
--- a/src/lease/grant.rs
+++ b/src/lease/grant.rs
@@ -43,7 +43,7 @@ impl From<Duration> for LeaseGrantRequest {
 pub struct LeaseGrantResponse {
     pub header: ResponseHeader,
     pub id: LeaseId,
-    pub ttl: u64,
+    pub ttl: i64,
 }
 
 impl From<crate::proto::etcdserverpb::LeaseGrantResponse> for LeaseGrantResponse {
@@ -51,7 +51,7 @@ impl From<crate::proto::etcdserverpb::LeaseGrantResponse> for LeaseGrantResponse
         Self {
             header: From::from(proto.header.expect("must fetch header")),
             id: proto.id,
-            ttl: proto.ttl as u64,
+            ttl: proto.ttl,
         }
     }
 }

--- a/src/lease/keep_alive.rs
+++ b/src/lease/keep_alive.rs
@@ -11,7 +11,7 @@ impl LeaseKeepAliveRequest {
     /// Creates a new LeaseKeepAliveRequest which will refresh the specified lease.
     pub fn new(id: LeaseId) -> Self {
         Self {
-            proto: etcdserverpb::LeaseKeepAliveRequest { id: id as i64 },
+            proto: etcdserverpb::LeaseKeepAliveRequest { id },
         }
     }
 }
@@ -26,7 +26,7 @@ impl From<LeaseKeepAliveRequest> for crate::proto::etcdserverpb::LeaseKeepAliveR
 pub struct LeaseKeepAliveResponse {
     pub header: ResponseHeader,
     pub id: LeaseId,
-    pub ttl: u64,
+    pub ttl: i64,
 }
 
 impl From<crate::proto::etcdserverpb::LeaseKeepAliveResponse> for LeaseKeepAliveResponse {
@@ -34,7 +34,7 @@ impl From<crate::proto::etcdserverpb::LeaseKeepAliveResponse> for LeaseKeepAlive
         Self {
             header: From::from(proto.header.expect("must fetch header")),
             id: proto.id,
-            ttl: proto.ttl as u64,
+            ttl: proto.ttl,
         }
     }
 }

--- a/src/lease/time_to_live.rs
+++ b/src/lease/time_to_live.rs
@@ -7,19 +7,16 @@ pub struct LeaseTimeToLiveRequest {
 }
 
 impl LeaseTimeToLiveRequest {
-    /// Creates a new LeaseGrantRequest with the specified TTL.
-    pub fn new(id: u64) -> Self {
+    /// Creates a new LeaseTimeToLiveRequest with the specified lease id.
+    pub fn new(id: LeaseId) -> Self {
         Self {
-            proto: etcdserverpb::LeaseTimeToLiveRequest {
-                id: id as i64,
-                keys: false,
-            },
+            proto: etcdserverpb::LeaseTimeToLiveRequest { id, keys: false },
         }
     }
 
     /// Set custom lease ID.
     pub fn with_id(mut self, id: LeaseId) -> Self {
-        self.proto.id = id as i64;
+        self.proto.id = id;
         self
     }
 
@@ -35,9 +32,9 @@ impl From<LeaseTimeToLiveRequest> for crate::proto::etcdserverpb::LeaseTimeToLiv
     }
 }
 
-impl From<u64> for LeaseTimeToLiveRequest {
-    fn from(watch_id: u64) -> Self {
-        Self::new(watch_id)
+impl From<LeaseId> for LeaseTimeToLiveRequest {
+    fn from(lease_id: LeaseId) -> Self {
+        Self::new(lease_id)
     }
 }
 
@@ -45,7 +42,7 @@ impl From<u64> for LeaseTimeToLiveRequest {
 pub struct LeaseTimeToLiveResponse {
     pub header: ResponseHeader,
     pub id: LeaseId,
-    pub ttl: u64,
+    pub ttl: i64,
 }
 
 impl From<crate::proto::etcdserverpb::LeaseTimeToLiveResponse> for LeaseTimeToLiveResponse {
@@ -53,7 +50,7 @@ impl From<crate::proto::etcdserverpb::LeaseTimeToLiveResponse> for LeaseTimeToLi
         Self {
             header: From::from(proto.header.expect("must fetch header")),
             id: proto.id,
-            ttl: proto.ttl as u64,
+            ttl: proto.ttl,
         }
     }
 }


### PR DESCRIPTION
The TTL was being cast to u64, but it really should be an i64. When the lease is expired the ttl on a `LeaseTimeToLiveRequest` is returned as `-1` for example.

Also changed the `LeaseTimeToLiveRequest` to use the `LeaseId` type instead of u64.