### PR TITLE
feat(watch): set `hasleader` metadata

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -363,11 +363,12 @@ impl WatchOp for Client {
 
         tx.send(req.into().into()).await?;
 
-        let resp = self
-            .watch_client
-            .clone()
-            .watch(ReceiverStream::new(rx))
-            .await?;
+        let mut req = tonic::Request::new(ReceiverStream::new(rx));
+
+        req.metadata_mut()
+            .insert("hasleader", "true".try_into().unwrap());
+
+        let resp = self.watch_client.clone().watch(req).await?;
 
         let mut inbound = resp.into_inner();
 


### PR DESCRIPTION
According to [comment of `Watcher` in etcd repo](https://github.com/etcd-io/etcd/blob/main/client/v3/watch.go#L68) 
> In order to prevent a watch stream being stuck in a partitioned node, make sure to wrap context with "WithRequireLeader".

The `WithRequireLeader` function set the metadata `hasleader` to `true`, and `etcdctl` has done [this](https://github.com/etcd-io/etcd/blob/main/etcdctl/ctlv3/command/watch_command.go#L163), so maybe we should do the same?
Another way is to provide a function to set metadata of requests, but I believe set `hasleader` in watch is what etcd recommended since it's crucial to know if the current etcd endpoint is working  properly or not.
