### PR TITLE
fix(lease): should not panic on keep_alive

### DIFF
--- a/src/lease/mod.rs
+++ b/src/lease/mod.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
 use tonic::Streaming;
 
-use crate::Result;
+use crate::{Error, Result};
 
 pub type LeaseId = i64;
 
@@ -69,7 +69,7 @@ impl LeaseKeepAlive {
         self.req_tx
             .send(req.into())
             .await
-            .expect("emit keep alive request to channel");
+            .map_err(|_| Error::ChannelClosed)?;
 
         Ok(match self.resp_rx.message().await? {
             Some(resp) => Some(resp.into()),


### PR DESCRIPTION
Currently in `LeaseKeepAlive`, calling the `keep_alive` function may cause a panic if a send operation is performed on `req_tx`.

There may be some network fluctuations due to poor network conditions in my usage environment (due to cross-border use). I have a keep-alive logic that calls `keep_alive_for` for retries during fluctuations, which caused this panic in actual scenarios.
```
thread 'tokio-runtime-worker' panicked at 'emit keep alive request to channel: SendError(LeaseKeepAliveRequest { id: 7587869483910042079 })', /home/.cargo/registry/src/index.crates.io-6f17d22bba15001f/etcd-rs-1.0.0/src/lease/mod.rs:72:14
```

Therefore, when send fails, I use the same logic as keep_alive_for to return a channel close error.